### PR TITLE
Bind directives update

### DIFF
--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -107,11 +107,29 @@ const bindDirectiveMap = {
   value: (value: Signal, element: HTMLInputElement | HTMLSelectElement) => {
     if (!isReactive(value))
       raise(`The bind:value directive's value must be a signal.`);
-    effect(() => {
+    function bindValueEff() {
       element.value = value.value as any;
-    });
+    }
+    effect(bindValueEff);
     element.addEventListener("input", ({ currentTarget }) => {
-      value.value = (currentTarget as any)?.value;
+      value.value = (currentTarget as typeof element).value;
+    });
+    element.addEventListener("remove:node", () => value.removeEffect(bindValueEff), {
+      once: true
+    });
+  },
+  open: (value: Signal, element: HTMLDetailsElement) => {
+    if (!isReactive(value))
+      raise(`The bind:value directive's value must be a signal.`);
+    function bindOpenEff() {
+      element.open = value.value as any;
+    }
+    effect(bindOpenEff);
+    element.addEventListener("toggle", ({ currentTarget }) => {
+      value.value = (currentTarget as typeof element).open;
+    });
+    element.addEventListener("remove:node", () => value.removeEffect(bindOpenEff), {
+      once: true
     });
   },
 };

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -121,7 +121,7 @@ function setProps(props: Proptype | null, element: NixixElementType) {
           return warn(
             `The ${k} directive value cannot be null or undefined. Skipping directive parsing`
           );
-        Nixix.handleDirectives('bind:', k.slice(5), v, element);
+        Nixix.handleDirectives('bind:', k.slice(5) as any, v, element);
       } else {
         setAttribute(element, k, v as ValueType);
       }

--- a/dom/utilVars.ts
+++ b/dom/utilVars.ts
@@ -156,6 +156,8 @@ export const PROP_ALIASES: {
   },
   value: {
     $: 'value',
-    INPUT: 1,
   },
+  textContent: {
+    $: 'textContent',
+  }
 } as const;

--- a/primitives/Signal.ts
+++ b/primitives/Signal.ts
@@ -25,7 +25,7 @@ export class Signal {
 
   set value(newVal: Primitive) {
     this._value = newVal;
-    queueMicrotask(() => (this.$$__deps?.forEach(fn => fn?.())))
+    this.$$__deps?.forEach(fn => fn?.())
   }
 
   public removeEffect(fn: CallableFunction) {

--- a/primitives/Signal.ts
+++ b/primitives/Signal.ts
@@ -25,7 +25,7 @@ export class Signal {
 
   set value(newVal: Primitive) {
     this._value = newVal;
-    this.$$__deps?.forEach(fn => fn?.())
+    queueMicrotask(() => (this.$$__deps?.forEach(fn => fn?.())))
   }
 
   public removeEffect(fn: CallableFunction) {

--- a/primitives/types/index.d.ts
+++ b/primitives/types/index.d.ts
@@ -23,9 +23,12 @@ export type MemoSignal<S> = Signal<S>;
 
 export type MemoStore<O> = Store<O>;
 
+export interface RefObject<T> {
+  readonly current: T;
+}
+
 export interface MutableRefObject<T> {
   current: T;
-  refId?: number;
   nextElementSibling: Element;
   prevElementSibling: Element;
   parent: HTMLElement;
@@ -84,11 +87,9 @@ type Deps = (Signal<Primitive> | Store<NonPrimitive>)[];
  */
 export function memo<S extends Primitive>(
   fn: () => S,
-  deps: Deps
 ): MemoSignal<S>;
 export function memo<S extends NonPrimitive>(
   fn: () => S,
-  deps: Deps
 ): MemoStore<S>;
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,8 @@ type Booleanish = boolean | "true" | "false";
 export = Nixix;
 export as namespace Nixix;
 
+Details
+
 declare namespace Nixix {
   /**
    * @deprecated fragment - esbuild provides support for 'fragment' string
@@ -640,6 +642,7 @@ declare namespace Nixix {
   }
 
   interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
+    "bind:open"?: Signal<boolean>;
     open?: boolean | undefined;
     "on:toggle"?: NativeEvents.NixixEventHandler<T>;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -975,7 +975,8 @@ declare namespace Nixix {
 
   interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
     autocomplete?: string;
-    cols?: number;
+    "bind:value": Signal<string>;
+    cols?: number | string;
     dirname?: string;
     disabled?: boolean;
     form?: string;
@@ -985,7 +986,7 @@ declare namespace Nixix {
     placeholder?: string;
     readonly?: boolean;
     required?: boolean;
-    rows?: number;
+    rows?: number | string;
     value?: string | string[] | number;
     wrap?: string;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 import * as CSS from "csstype";
 import { AriaRole } from "./aria";
 import * as NativeEvents from "./eventhandlers";
-import { MutableRefObject, Signal } from "../primitives/types";
+import { MutableRefObject as $MutableRefObject, RefObject as $RefObject, Signal } from "../primitives/types";
 
 type Booleanish = boolean | "true" | "false";
 
@@ -45,11 +45,15 @@ declare namespace Nixix {
 
   type NixixNode = JSX.ElementType | Iterable<JSX.ElementType>;
 
+  type RefObject<T> = $RefObject<T>;
+
+  type MutableRefObject<T> = $MutableRefObject<T>;
+
   type ExoticComponent<P> = (props: P) => someView;
 
   type RouteExoticComponent<T> = T;
 
-  type RefFunction<T> = (({current}: {current: T}) => void)
+  type RefFunction<T> = (({current}: RefObject<T>) => void)
 
   interface CSSProperties extends CSS.Properties<string, number> {}
 
@@ -955,10 +959,11 @@ declare namespace Nixix {
   }
 
   interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    "bind:styles": string
     media?: string;
     nonce?: string;
     scoped?: boolean;
-    type?: string;
+    type?: 'text/css';
   }
 
   interface TableHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
Bind directive updates functionality done for all the elements NixixJS can cover for now.

`bind:value` works for textarea, select, and input elements;

`bind:open` works for details elements;

`bind:ref` works for all elements

`bind:styles` works for all style elements;