### PR TITLE
[updated] symbols for reactive indexing

### DIFF
--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -39,7 +39,7 @@ export function flatten(arr: Array<any>) {
 }
 
 export function getSignalValue(signal: Signal) {
-  if (signal.$$__reactive) {
+  if (isReactive(signal)) {
     const value = signal.value;
     return value;
   } else return signal as any;
@@ -55,13 +55,13 @@ export function fillInChildren(
   return (child: ChildrenType[number]) => {
     if (typeof child === "object") {
       // signal check
-      if ((child as Signal)?.$$__reactive) {
+      if (isReactive(child)) {
         const signal = child as Signal;
         const text = addText(element);
         // @ts-expect-error
         function textEff() {
           const value = signal.value;
-          queueMicrotask(() => (text.textContent = nonNull(value, "")))
+          queueMicrotask(() => (text.textContent = nonNull(value, "")));
         }
         text.addEventListener(
           "remove:node",
@@ -105,11 +105,16 @@ const bindDirectiveMap = {
       return;
     }
   },
-  value: (value: Signal, element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement) => {
+  value: (
+    value: Signal,
+    element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+  ) => {
     if (!isReactive(value))
       raise(`The bind:value directive's value must be a signal.`);
-    if (!(['TEXTAREA', 'INPUT', 'SELECT'].includes(element.tagName)))
-      raise(`The bind:value directive cannot be used on <${element.tagName.toLowerCase()}> elements.`)
+    if (!["TEXTAREA", "INPUT", "SELECT"].includes(element.tagName))
+      raise(
+        `The bind:value directive cannot be used on <${element.tagName.toLowerCase()}> elements.`
+      );
     function bindValueEff() {
       element.value = value.value as any;
     }
@@ -117,15 +122,21 @@ const bindDirectiveMap = {
     element.addEventListener("input", ({ currentTarget }) => {
       value.value = (currentTarget as typeof element).value;
     });
-    element.addEventListener("remove:node", () => value.removeEffect(bindValueEff), {
-      once: true
-    });
+    element.addEventListener(
+      "remove:node",
+      () => value.removeEffect(bindValueEff),
+      {
+        once: true,
+      }
+    );
   },
   open: (value: Signal, element: HTMLDetailsElement) => {
     if (!isReactive(value))
       raise(`The bind:open directive's value must be a signal.`);
-    if (!(['DETAILS'].includes(element.tagName)))
-      raise(`The bind:open directive cannot be used on <${element.tagName.toLowerCase()}> elements.`)
+    if (!["DETAILS"].includes(element.tagName))
+      raise(
+        `The bind:open directive cannot be used on <${element.tagName.toLowerCase()}> elements.`
+      );
     function bindOpenEff() {
       element.open = value.value as any;
     }
@@ -133,17 +144,23 @@ const bindDirectiveMap = {
     element.addEventListener("toggle", ({ currentTarget }) => {
       value.value = (currentTarget as typeof element).open;
     });
-    element.addEventListener("remove:node", () => value.removeEffect(bindOpenEff), {
-      once: true
-    });
+    element.addEventListener(
+      "remove:node",
+      () => value.removeEffect(bindOpenEff),
+      {
+        once: true,
+      }
+    );
   },
   styles: (value: string, element: HTMLStyleElement) => {
     if (isReactive(value))
       raise(`The bind:styles directive's value must be a string.`);
-    if (!(['style'].includes(element.tagName)))
-      raise(`The bind:styles directive cannot be used on <${element.tagName.toLowerCase()}> elements.`)
-    element.textContent = value
-  }
+    if (!["style"].includes(element.tagName))
+      raise(
+        `The bind:styles directive cannot be used on <${element.tagName.toLowerCase()}> elements.`
+      );
+    element.textContent = value;
+  },
 };
 
 export const directiveMap = {
@@ -152,8 +169,7 @@ export const directiveMap = {
 
 type DirectiveMap = typeof directiveMap;
 
-type KeyOfAllDirectives =
-  | keyof DirectiveMap["bind:"];
+type KeyOfAllDirectives = keyof DirectiveMap["bind:"];
 
 export function handleDirectives_(
   prefix: keyof DirectiveMap,

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -1,5 +1,5 @@
 import { Signal } from "../primitives/classes";
-import { entries } from "../primitives/helpers";
+import { entries, isReactive } from "../primitives/helpers";
 import { effect } from "../primitives/index";
 import { isFunction, isNull, nonNull, raise, warn } from "../shared";
 import Component from "./Component";
@@ -45,7 +45,7 @@ function setAttribute(
     return warn(
       `The ${attrName} prop cannot be null or undefined. Skipping attribute parsing.`
     );
-  if ((attrValue as Signal).$$__reactive) {
+  if (isReactive(attrValue)) {
     const signal = attrValue as Signal;
     // @ts-expect-error
     function propEff() {
@@ -76,7 +76,7 @@ function setStyle(element: NixixElementType, styleValue: StyleValueType) {
         `The ${styleKey} CSS property cannot be null or undefined. Skipping CSS property parsing.`
       );
 
-    if ((value as Signal).$$__reactive) {
+    if (isReactive(value)) {
       const signal = value as Signal;
       // @ts-expect-error
       function styleEff() {
@@ -121,7 +121,7 @@ function setProps(props: Proptype | null, element: NixixElementType) {
           return warn(
             `The ${k} directive value cannot be null or undefined. Skipping directive parsing`
           );
-        Nixix.handleDirectives('bind:', k.slice(5) as any, v, element);
+        Nixix.handleDirectives("bind:", k.slice(5) as any, v, element);
       } else {
         setAttribute(element, k, v as ValueType);
       }

--- a/primitives/Signal.ts
+++ b/primitives/Signal.ts
@@ -1,16 +1,16 @@
+import { DEPS, REACTIVE, TOPRIMITIVE } from "../shared";
 import { EFFECT_STACK } from "./shared";
 import { type Primitive } from "./types";
 
 export class Signal {
-  $$__reactive = true;
-  $$__deps = new Set<CallableFunction>()
+  [REACTIVE] = true;
+  
+  [DEPS] = new Set<CallableFunction>();
 
-  constructor(private _value: Primitive) {
-    const symbol = Symbol.toPrimitive
-    // @ts-expect-error
-    this[symbol] = function toPrimitive() {
-      return this.value;
-    }
+  constructor(private _value: Primitive) {}
+
+  [TOPRIMITIVE]() {
+    return this.value;
   }
 
   public toJSON() {
@@ -19,18 +19,18 @@ export class Signal {
 
   get value() {
     const RUNNING = EFFECT_STACK[EFFECT_STACK.length - 1];
-    if (RUNNING) this.$$__deps?.add(RUNNING);
+    if (RUNNING) this[DEPS]?.add(RUNNING);
     return this._value
   }
 
   set value(newVal: Primitive) {
     this._value = newVal;
-    this.$$__deps?.forEach(fn => fn?.())
+    this[DEPS]?.forEach(fn => fn?.())
   }
 
   public removeEffect(fn: CallableFunction) {
-    if (this.$$__deps?.has(fn)) {
-      this.$$__deps?.delete(fn) 
+    if (this[DEPS]?.has(fn)) {
+      this[DEPS]?.delete(fn) 
       return true;
     } else return false;
   }

--- a/primitives/helpers.ts
+++ b/primitives/helpers.ts
@@ -1,3 +1,4 @@
+import { REACTIVE } from "../shared";
 import { type EmptyObject } from "../dom";
 import { Signal, Store } from "./classes";
 import { type NonPrimitive } from "./types";
@@ -61,7 +62,7 @@ function forEach<T>(
 }
 
 function isReactive(value: any) {
-  return (value as Signal | Store).$$__reactive as boolean;
+  return (value as Signal | Store)?.[REACTIVE] as boolean;
 }
 
 export {

--- a/primitives/types/index.d.ts
+++ b/primitives/types/index.d.ts
@@ -144,6 +144,10 @@ export function renderEffect(
   callbackFn: CallableFunction,
 ): void;
 
+/**
+ * @deprecated PLEASE DO NOT USE THIS FUNCTION;
+ * SIGNALS CAN JUST REMOVE EFFECTS
+ */
 export function removeSignal(
   signals: Array<Store<any> | Signal<any>> | Store<any> | Signal<any>
 ): void;

--- a/router/helpers.ts
+++ b/router/helpers.ts
@@ -42,13 +42,7 @@ export function isNull(val: any) {
 }
 
 export function getLink(link: string | Store | Signal): string {
-  switch (true) {
-    // @ts-expect-error
-    case link.$$__reactive:
-      return getSignalValue(link as Signal) || '' as any;
-    default:
-      return link as any;
-  }
+  return getSignalValue(link as any) || '' 
 }
 
 type ForEachParams<T> = Parameters<Array<T>["forEach"]>;

--- a/shared.ts
+++ b/shared.ts
@@ -2,6 +2,8 @@ export const REACTIVE = Symbol.for('reactive')
 
 export const DEPS = Symbol.for('deps')
 
+export const TOPRIMITIVE = Symbol.toPrimitive;
+
 export function raise(message: string) {
   throw `${message}`;
 }


### PR DESCRIPTION
Symbols are now used to index reactive primitives. 

This is done so that the dividing algorithm won't remove the symbols properties that hold dependencies in nested stores